### PR TITLE
Reworked validation data selection

### DIFF
--- a/snrv/snrv.py
+++ b/snrv/snrv.py
@@ -516,8 +516,8 @@ class Snrv(nn.Module):
         """
         create training and validation data loader. Since the input data is a time series, the split cannot
         be random. If `data` is a torch.tensor, the final val_frac of the data is used as the validation set.
-        If `data` is a list of torch.tensors, the (val_frac*total data) of the last tensor is used. If this exceeds
-        the length of the last tensor, a warning is printed and all data in last tensor is used for validation.
+        If `data` is a list of torch.tensors, the ceil(val_frac*len(data)) of the trajectories are used. If the
+        trajectories are not of the same length, the shortest trajectory is used for validation.
 
         Parameters
         ----------

--- a/snrv/snrv.py
+++ b/snrv/snrv.py
@@ -544,7 +544,7 @@ class Snrv(nn.Module):
             self._train_loader = DataLoader(
                 dataset=train_dataset,
                 batch_size=self.batch_size,
-                shuffle=True,
+                shuffle=False,
                 num_workers=self.num_workers,
             )
             val_dataset = DatasetSnrv(
@@ -829,30 +829,30 @@ class Snrv(nn.Module):
                 if hasattr(self, "scheduler"):
                     self.scheduler.step()
 
-                self.eval()
-                with torch.no_grad():
-                    val_losses = []
-                    if self._val_loader is None:
-                        validation_loss = np.NaN
-                        validation_losses.append(validation_loss)
-                    else:
-                        for x_t0_batch, x_tt_batch, pathweight_batch in self._val_loader:
-                            x_t0_batch = x_t0_batch.to(self.device)
-                            x_tt_batch = x_tt_batch.to(self.device)
-                            pathweight_batch = pathweight_batch.to(self.device)
-                            z_t0_batch, z_tt_batch = self(x_t0_batch, x_tt_batch)
-                            val_loss = self._loss_fn(
-                                z_t0_batch, z_tt_batch, pathweight_batch
-                            )
-                            val_loss = val_loss.item()
-                            val_losses.append(val_loss)
-                        validation_loss = float(np.mean(val_losses))
-                        validation_losses.append(validation_loss)
+            self.eval()
+            with torch.no_grad():
+                val_losses = []
+                if self._val_loader is None:
+                    validation_loss = np.NaN
+                    validation_losses.append(validation_loss)
+                else:
+                    for x_t0_batch, x_tt_batch, pathweight_batch in self._val_loader:
+                        x_t0_batch = x_t0_batch.to(self.device)
+                        x_tt_batch = x_tt_batch.to(self.device)
+                        pathweight_batch = pathweight_batch.to(self.device)
+                        z_t0_batch, z_tt_batch = self(x_t0_batch, x_tt_batch)
+                        val_loss = self._loss_fn(
+                            z_t0_batch, z_tt_batch, pathweight_batch
+                        )
+                        val_loss = val_loss.item()
+                        val_losses.append(val_loss)
+                    validation_loss = float(np.mean(val_losses))
+                    validation_losses.append(validation_loss)
 
-                print(
-                    "[Epoch %d]\t training loss = %.3f\t validation loss = %.3f"
-                    % (epoch, training_loss, validation_loss)
-                )
+            print(
+                "[Epoch %d]\t training loss = %.3f\t validation loss = %.3f"
+                % (epoch, training_loss, validation_loss)
+            )
 
         self.training_losses = training_losses
         self.validation_losses = validation_losses

--- a/snrv/snrv.py
+++ b/snrv/snrv.py
@@ -606,6 +606,8 @@ class Snrv(nn.Module):
                         val_size = int(np.ceil(val_size)) # adjust val_frac to equal a whole number of trajectories
                         warn(f"""Selected validation size is larger/smaller than a single trajectory. Validation percentage will be changed to %{val_size/len(data)*100}.
                             You can change this behavior by reintializing the model with `val_frac=0` and manually feed the validation data using `val_data` argument of `fit`.""", stacklevel=2)
+                    else:
+                        val_size = int(val_size) # adjust val_frac to equal a whole number of trajectories
                     _create_dataloaders(data[:-val_size], data[-val_size:], ln_dynamical_weight, thermo_weight)
                 
                 else: # if trajectories are not of same length

--- a/snrv/snrv.py
+++ b/snrv/snrv.py
@@ -605,14 +605,14 @@ class Snrv(nn.Module):
                     if val_size != np.ceil(val_size):
                         val_size = int(np.ceil(val_size)) # adjust val_frac to equal a whole number of trajectories
                         warn(f"""Selected validation size is larger/smaller than a single trajectory. Validation percentage will be changed to %{val_size/len(data)*100}.
-                            You can change this behavior by reintializing the model with `val_frac=0` and manually feed the validation data using `val_data` argument of `fit`.""")
+                            You can change this behavior by reintializing the model with `val_frac=0` and manually feed the validation data using `val_data` argument of `fit`.""", stacklevel=2)
                     _create_dataloaders(data[:-val_size], data[-val_size:], ln_dynamical_weight, thermo_weight)
                 
                 else: # if trajectories are not of same length
                     len_list_sorted = np.argsort(len_list)[::-1] # descending order of trajectory lengths
                     data = [data[i] for i in len_list_sorted] # sort data based on trajectory length
                     warn(f"""Trajectories in the provided list are not the same length. The shortest trajectory will be selected for validation (validation percentage = {data[-1].size(0)/sum(len_list)*100}).
-                            You can change this behavior by reintializing the model with `val_frac=0` and manually setting the validation data using `val_data` argument of `fit`.""")
+                            You can change this behavior by reintializing the model with `val_frac=0` and manually setting the validation data using `val_data` argument of `fit`.""", stacklevel=2)
                     _create_dataloaders(data[:-1], data[-1], ln_dynamical_weight, thermo_weight)
         return None
     

--- a/snrv/snrv.py
+++ b/snrv/snrv.py
@@ -606,7 +606,7 @@ class Snrv(nn.Module):
                         val_size = int(np.ceil(val_size)) # adjust val_frac to equal a whole number of trajectories
                         warn(f"""Selected validation size is larger/smaller than a single trajectory. Validation percentage will be changed to %{val_size/len(data)*100}.
                             You can change this behavior by reintializing the model with `val_frac=0` and manually feed the validation data using `val_data` argument of `fit`.""")
-                        _create_dataloaders(data[:-val_size], data[-val_size:], ln_dynamical_weight, thermo_weight)
+                    _create_dataloaders(data[:-val_size], data[-val_size:], ln_dynamical_weight, thermo_weight)
                 
                 else: # if trajectories are not of same length
                     len_list_sorted = np.argsort(len_list)[::-1] # descending order of trajectory lengths

--- a/snrv/snrv.py
+++ b/snrv/snrv.py
@@ -544,7 +544,7 @@ class Snrv(nn.Module):
             self._train_loader = DataLoader(
                 dataset=train_dataset,
                 batch_size=self.batch_size,
-                shuffle=False,
+                shuffle=True,
                 num_workers=self.num_workers,
             )
             val_dataset = DatasetSnrv(


### PR DESCRIPTION
Since the input data for the SRVs are time series, randomly splitting the data for training and validation is not an option. The dataset creation workflow now supports three common cases for automatic train/validation data splitting as well as allowing the user to feed the validation and train data manually.
If `val_frac` is set to zero during model definition, all data fed to the `fit` function is treated as training data, and no validation will be performed. The user can manually provide the validation data to the `fit` function using the `val_data` keyword.
If  `val_frac` is non-zero, one of the three cases can happen:

1. If the input data is a single `torch.tensor` (a single continuous trajectory), the last `val_frac` of the data is separated and used for validation.
2.  If the input data is a `list` of `torch.tensor`s:

     * If all the trajectories are the same length, `ceil(val_frac*len(data))` of the trajectories are used for validation. E.g., if a list of 5 trajectories of the same length is given as input and `val_frac=0.2`, the last trajectory in the list will be used for validation. If `val_frac*len(data)` is not an integer, it will be rounded up. E.g., a list of 5 trajectories with `val_frac=0.25` will use 2 of the five trajectories (without splitting any of the trajectories) for validation (this means `val_frac` will be automatically adjusted to `0.4` by the code).

     * If all the trajectories are not the same length, the shortest trajectory is used for validation.
The user can override the above default behavior through `val_frac=0.0` and the `val_data`  keyword.

I suggest a full review of the new lines before merging.